### PR TITLE
Add support for CQL paging over sorted searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 3.0.6.1 (upcoming)
 
-* Add support for top-k searches using IN operator
+* Add support for CQL paging over sorted searches
+* Add support for sorted searches using IN operator
 
 ## 3.0.6.0 (27 May 2016)
 

--- a/README.rst
+++ b/README.rst
@@ -64,16 +64,16 @@ Stratio’s Cassandra Lucene Index and its integration with Lucene search techno
 
 -  Full text search (language-aware analysis, wildcard, fuzzy, regexp)
 -  Boolean search (and, or, not)
--  Top-k queries (relevance scoring, sort by value, sort by distance)
+-  Sorting by relevance, column value, and distance)
 -  Geospatial indexing (points, lines, polygons and their multiparts)
 -  Geospatial transformations (bounding box, buffer, centroid, convex hull, union, difference, intersection)
 -  Geospatial operations (intersects, contains, is within)
 -  Bitemporal search (valid and transaction time durations)
 -  CQL complex types (list, set, map, tuple and UDT)
 -  CQL user defined functions (UDF)
--  Third-party CQL-based drivers compatibility
--  Paging over filters
+-  CQL paging, even with sorted searches
 -  Columns with TTL
+-  Third-party CQL-based drivers compatibility
 -  Spark and Hadoop compatibility
 
 Not yet supported:
@@ -81,9 +81,8 @@ Not yet supported:
 -  Thrift API
 -  Legacy compact storage option
 -  Indexing ``counter`` columns
--  Static columns
+-  Indexing static columns
 -  Other partitioners than Murmur3
--  Paging over top-k searches
 
 Requirements
 ------------

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/Index.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/Index.java
@@ -415,7 +415,6 @@ public class Index implements org.apache.cassandra.index.Index {
      */
     @Override
     public Searcher searcherFor(ReadCommand command) {
-        System.out.println("*** SEARCHING " + command.getClass());
         logger.trace("Getting searcher for {}", command);
         try {
             return service.searcher(command);

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/IndexPagingState.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/IndexPagingState.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (C) 2014 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.cassandra.lucene;
+
+import com.google.common.base.MoreObjects;
+import com.stratio.cassandra.lucene.search.SearchBuilder;
+import com.stratio.cassandra.lucene.util.SimplePartitionIterator;
+import com.stratio.cassandra.lucene.util.SimpleRowIterator;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.db.rows.RowIterator;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.service.LuceneStorageProxy;
+import org.apache.cassandra.service.pager.PagingState;
+import org.apache.cassandra.utils.Pair;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.*;
+
+import static com.stratio.cassandra.lucene.util.ByteBufferUtils.compose;
+import static com.stratio.cassandra.lucene.util.ByteBufferUtils.decompose;
+import static java.util.stream.Collectors.toList;
+import static org.apache.cassandra.db.SinglePartitionReadCommand.Group;
+import static org.apache.cassandra.service.LuceneStorageProxy.RangeMerger;
+import static org.apache.cassandra.utils.ByteBufferUtil.readShortLength;
+import static org.apache.cassandra.utils.ByteBufferUtil.writeShortLength;
+
+/**
+ * The paging state of a CQL query using Lucene. It tracks the primary keys of the last seen rows for each internal read
+ * command of a CQL query. It also keeps the count of the remaining rows. This state can be serialized to be attached to
+ * a CQL {@link PagingState} and/or to a search predicate.
+ *
+ * @author Andres de la Pena {@literal <adelapena@stratio.com>}
+ */
+public class IndexPagingState {
+
+    /** The number of remaining rows. */
+    private int remaining;
+
+    /** If there could be more results. */
+    private boolean hasMorePages = true;
+
+    /** The last row positions */
+    private final Map<DecoratedKey, Clustering> entries;
+
+    /**
+     * Constructor taking the remaining rows.
+     *
+     * @param remaining the number of remaining rows to be retrieved
+     */
+    private IndexPagingState(int remaining) {
+        this.remaining = remaining;
+        this.entries = new LinkedHashMap<>();
+    }
+
+    /**
+     * Returns the number of remaining rows.
+     *
+     * @return the number of remaining rows
+     */
+    int remaining() {
+        return remaining;
+    }
+
+    private void clear(AbstractBounds<PartitionPosition> bounds) {
+        List<DecoratedKey> keysToRemove = new LinkedList<>();
+        for (Map.Entry<DecoratedKey, Clustering> entry : entries.entrySet()) {
+            DecoratedKey key = entry.getKey();
+            if (bounds.contains(key)) {
+                keysToRemove.add(key);
+            }
+        }
+        keysToRemove.forEach(entries::remove);
+    }
+
+    /**
+     * Returns the primary key of the last seen row for the specified {@link ReadCommand}.
+     *
+     * @param command a read command
+     * @return the primary key of the last seen row for {@code command}
+     */
+    Pair<DecoratedKey, Clustering> forCommand(ReadCommand command) {
+        if (command instanceof SinglePartitionReadCommand) {
+            return forCommand((SinglePartitionReadCommand) command);
+        } else if (command instanceof PartitionRangeReadCommand) {
+            return forCommand((PartitionRangeReadCommand) command);
+        } else {
+            throw new IndexException("Unsupported read command type: %s", command.getClass());
+        }
+    }
+
+    private Pair<DecoratedKey, Clustering> forCommand(SinglePartitionReadCommand command) {
+        DecoratedKey key = command.partitionKey();
+        Clustering clustering = entries.get(key);
+        if (clustering == null) {
+            return null;
+        }
+        return Pair.create(key, clustering);
+    }
+
+    private Pair<DecoratedKey, Clustering> forCommand(PartitionRangeReadCommand command) {
+        DataRange dataRange = command.dataRange();
+        for (Map.Entry<DecoratedKey, Clustering> entry : entries.entrySet()) {
+            DecoratedKey key = entry.getKey();
+            if (dataRange.contains(key)) {
+                Clustering clustering = entry.getValue();
+                return Pair.create(key, clustering);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Adds this paging state to the specified {@link ReadQuery}.
+     *
+     * @param query a CQL query using the Lucene index
+     * @throws ReflectiveOperationException
+     */
+    void rewrite(ReadQuery query) throws ReflectiveOperationException {
+        if (query instanceof Group) {
+            rewrite((Group) query);
+        } else if (query instanceof ReadCommand) {
+            rewrite((ReadCommand) query);
+        } else {
+            throw new InvalidRequestException("Unsupported query type " + query.getClass());
+        }
+    }
+
+    private void rewrite(ReadCommand command) throws ReflectiveOperationException {
+        RowFilter rowFilter = command.rowFilter();
+        for (RowFilter.Expression expression : command.rowFilter().getExpressions()) {
+            if (expression.isCustom()) {
+                RowFilter.CustomExpression oldExpression = (RowFilter.CustomExpression) expression;
+                rowFilter = rowFilter.without(oldExpression);
+                ByteBuffer value = oldExpression.getValue();
+                SearchBuilder searchBuilder = SearchBuilder.fromJson(UTF8Type.instance.compose(value));
+                searchBuilder.paging(this);
+                ByteBuffer newValue = UTF8Type.instance.decompose(searchBuilder.toJson());
+                Field field = RowFilter.Expression.class.getDeclaredField("value");
+                field.setAccessible(true);
+                field.set(oldExpression, newValue);
+            }
+        }
+    }
+
+    private void rewrite(Group group) throws ReflectiveOperationException {
+        for (SinglePartitionReadCommand command : group.commands) {
+            rewrite(command);
+        }
+    }
+
+    /**
+     * Returns a CQL {@link PagingState} containing this Lucene paging state.
+     *
+     * @return a CQL paging state
+     */
+    PagingState toPagingState() {
+        return hasMorePages ? new PagingState(toByteBuffer(), null, remaining, remaining) : null;
+    }
+
+    /**
+     * Returns the Lucene paging state contained in the specified CQL {@link PagingState}. If the specified paging state
+     * is {@code null}, then an empty Lucene paging state will be returned.
+     *
+     * @param state a CQL paging state
+     * @param limit the query user limit
+     * @return a Lucene paging state
+     */
+    static IndexPagingState build(PagingState state, int limit) {
+        return state == null ? new IndexPagingState(limit) : build(state.partitionKey);
+    }
+
+    /**
+     * Updates this paging state with the results of the specified query.
+     *
+     * @param query the query
+     * @param data the results of {@code query}
+     * @param consistency the query consistency level
+     * @return a copy of the query results
+     */
+    PartitionIterator update(ReadQuery query, PartitionIterator data, ConsistencyLevel consistency) {
+        if (query instanceof SinglePartitionReadCommand.Group) {
+            return update((SinglePartitionReadCommand.Group) query, data);
+        } else if (query instanceof PartitionRangeReadCommand) {
+            return update((PartitionRangeReadCommand) query, data, consistency);
+        } else {
+            throw new InvalidRequestException("Unsupported query type " + query.getClass());
+        }
+    }
+
+    private PartitionIterator update(Group group, PartitionIterator data) {
+        List<SimpleRowIterator> rowIterators = new LinkedList<>();
+
+        int count = 0;
+        while (data.hasNext()) {
+            RowIterator partition = data.next();
+            DecoratedKey key = partition.partitionKey();
+            while (partition.hasNext()) {
+                SimpleRowIterator newRowIterator = new SimpleRowIterator(partition);
+                rowIterators.add(newRowIterator);
+                Clustering clustering = newRowIterator.getRow().clustering();
+                entries.put(key, clustering);
+                if (remaining > 0) {
+                    remaining--;
+                }
+                count++;
+            }
+            partition.close();
+        }
+        data.close();
+
+        hasMorePages = remaining > 0 && count >= group.limits().count();
+
+        return new SimplePartitionIterator(rowIterators);
+    }
+
+    private PartitionIterator update(PartitionRangeReadCommand command, PartitionIterator data, ConsistencyLevel cl) {
+
+        // Collect query bounds
+        RangeMerger rangeMerger = LuceneStorageProxy.rangeMerger(command, cl);
+        List<AbstractBounds<PartitionPosition>> bounds = new LinkedList<>();
+        while (rangeMerger.hasNext()) {
+            bounds.add(rangeMerger.next().range);
+        }
+
+        List<SimpleRowIterator> rowIterators = new LinkedList<>();
+        int count = 0;
+        while (data.hasNext()) {
+            RowIterator partition = data.next();
+            DecoratedKey key = partition.partitionKey();
+            AbstractBounds<PartitionPosition> bound = bounds.stream()
+                                                            .filter(b -> b.contains(key))
+                                                            .findAny()
+                                                            .orElseGet(null);
+            while (partition.hasNext()) {
+                clear(bound);
+                SimpleRowIterator newRowIterator = new SimpleRowIterator(partition);
+                rowIterators.add(newRowIterator);
+                Clustering clustering = newRowIterator.getRow().clustering();
+                entries.put(key, clustering);
+                if (remaining > 0) {
+                    remaining--;
+                }
+                count++;
+            }
+            partition.close();
+        }
+        data.close();
+
+        hasMorePages = remaining > 0 && count >= command.limits().count();
+
+        return new SimplePartitionIterator(rowIterators);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("remaining", remaining).add("entries", entries).toString();
+    }
+
+    /**
+     * Returns a byte buffer representation of this. Thew returned result can be read with {@link #build(ByteBuffer)}.
+     *
+     * @return a byte buffer representing this
+     */
+    public ByteBuffer toByteBuffer() {
+        ByteBuffer[] entryValues = new ByteBuffer[entries.size()];
+        entries.entrySet().stream().map(entry -> {
+            DecoratedKey key = entry.getKey();
+            Clustering clustering = entry.getValue();
+            ByteBuffer[] clusteringValues = clustering.getRawValues();
+            ByteBuffer[] values = new ByteBuffer[1 + clusteringValues.length];
+            values[0] = key.getKey();
+            System.arraycopy(clusteringValues, 0, values, 1, clusteringValues.length);
+            return compose(values);
+        }).collect(toList()).toArray(entryValues);
+        ByteBuffer values = compose(entryValues);
+        ByteBuffer out = ByteBuffer.allocate(2 + values.remaining());
+        writeShortLength(out, remaining);
+        out.put(values);
+        out.flip();
+        return out;
+    }
+
+    /**
+     * Returns the paging state represented by the specified byte buffer, which should have been generated with {@link
+     * #toByteBuffer()}.
+     *
+     * @param bb a byte buffer generated by {@link #toByteBuffer()}
+     * @return the paging state reperesented by {@code bb}
+     */
+    public static IndexPagingState build(ByteBuffer bb) {
+        int remaining = readShortLength(bb);
+        IndexPagingState state = new IndexPagingState(remaining);
+        Arrays.asList(decompose(bb))
+              .stream()
+              .forEach(bbe -> {
+                  ByteBuffer[] values = decompose(bbe);
+                  DecoratedKey key = DatabaseDescriptor.getPartitioner().decorateKey(values[0]);
+                  Clustering clustering = new Clustering(Arrays.copyOfRange(values, 1, values.length));
+                  state.entries.put(key, clustering);
+              });
+        return state;
+    }
+}

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/IndexServiceSkinny.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/IndexServiceSkinny.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 
+import java.nio.ByteBuffer;
 import java.util.*;
 
 /**
@@ -119,6 +120,12 @@ class IndexServiceSkinny extends IndexService {
         PartitionPosition startPosition = dataRange.startKey();
         PartitionPosition stopPosition = dataRange.stopKey();
         return query(startPosition, stopPosition);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<Query> after(ByteBuffer key, ByteBuffer clustering) {
+        return key == null ? Optional.empty() : Optional.of(partitionMapper.query(key));
     }
 
     /** {@inheritDoc} */

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/IndexServiceSkinny.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/IndexServiceSkinny.java
@@ -30,7 +30,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 
-import java.nio.ByteBuffer;
 import java.util.*;
 
 /**
@@ -124,7 +123,7 @@ class IndexServiceSkinny extends IndexService {
 
     /** {@inheritDoc} */
     @Override
-    public Optional<Query> after(ByteBuffer key, ByteBuffer clustering) {
+    public Optional<Query> after(DecoratedKey key, Clustering clustering) {
         return key == null ? Optional.empty() : Optional.of(partitionMapper.query(key));
     }
 

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/IndexServiceWide.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/IndexServiceWide.java
@@ -19,6 +19,7 @@ import com.stratio.cassandra.lucene.column.Columns;
 import com.stratio.cassandra.lucene.index.DocumentIterator;
 import com.stratio.cassandra.lucene.key.KeyMapper;
 import com.stratio.cassandra.lucene.key.PartitionMapper;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.rows.Row;
@@ -32,6 +33,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 
+import java.nio.ByteBuffer;
 import java.util.*;
 
 import static org.apache.cassandra.db.PartitionPosition.Kind.MAX_BOUND;
@@ -203,6 +205,20 @@ class IndexServiceWide extends IndexService {
         // Return query, or empty if there are no restrictions
         BooleanQuery query = builder.build();
         return query.clauses().isEmpty() ? Optional.empty() : Optional.of(query);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<Query> after(ByteBuffer key, ByteBuffer clustering) {
+        if (key == null) {
+            return Optional.empty();
+        } else if (clustering == null) {
+            return Optional.of(partitionMapper.query(key));
+        } else {
+            DecoratedKey startDecoratedKey = DatabaseDescriptor.getPartitioner().decorateKey(key);
+            Clustering prefix = keyMapper.clustering(clustering);
+            return Optional.of(keyMapper.query(startDecoratedKey, prefix));
+        }
     }
 
     /** {@inheritDoc} */

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/IndexServiceWide.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/IndexServiceWide.java
@@ -19,7 +19,6 @@ import com.stratio.cassandra.lucene.column.Columns;
 import com.stratio.cassandra.lucene.index.DocumentIterator;
 import com.stratio.cassandra.lucene.key.KeyMapper;
 import com.stratio.cassandra.lucene.key.PartitionMapper;
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.rows.Row;
@@ -33,7 +32,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 
-import java.nio.ByteBuffer;
 import java.util.*;
 
 import static org.apache.cassandra.db.PartitionPosition.Kind.MAX_BOUND;
@@ -209,15 +207,13 @@ class IndexServiceWide extends IndexService {
 
     /** {@inheritDoc} */
     @Override
-    public Optional<Query> after(ByteBuffer key, ByteBuffer clustering) {
+    public Optional<Query> after(DecoratedKey key, Clustering clustering) {
         if (key == null) {
             return Optional.empty();
         } else if (clustering == null) {
             return Optional.of(partitionMapper.query(key));
         } else {
-            DecoratedKey startDecoratedKey = DatabaseDescriptor.getPartitioner().decorateKey(key);
-            Clustering prefix = keyMapper.clustering(clustering);
-            return Optional.of(keyMapper.query(startDecoratedKey, prefix));
+            return Optional.of(keyMapper.query(key, clustering));
         }
     }
 

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/index/DocumentIterator.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/index/DocumentIterator.java
@@ -43,12 +43,13 @@ public class DocumentIterator implements CloseableIterator<Pair<Document, ScoreD
     private final Query query;
     final int page;
     private final Deque<Pair<Document, ScoreDoc>> documents = new LinkedList<>();
-    private final Sort sort, mergeSort;
+    private final Sort sort, indexSort;
     private final Set<String> fields;
     private ScoreDoc after = null;
     private boolean finished = false;
     private IndexSearcher searcher;
     private int numRead = 0;
+    private final Query startQuery;
 
     /**
      * Builds a new iterator over the {@link Document}s satisfying the specified {@link Query}.
@@ -56,21 +57,39 @@ public class DocumentIterator implements CloseableIterator<Pair<Document, ScoreD
      * @param manager the Lucene index searcher manager
      * @param query the query to be satisfied by the documents
      * @param sort the sort in which the documents are going to be retrieved
-     * @param mergeSort the index natural sort
      * @param page the iteration page size
      * @param fields the names of the document fields to be loaded
      */
-    DocumentIterator(SearcherManager manager, Query query, Sort sort, Sort mergeSort, int page, Set<String> fields) {
+    DocumentIterator(SearcherManager manager,
+                     Sort indexSort,
+                     Query after,
+                     Query query,
+                     Sort sort,
+                     int page,
+                     Set<String> fields) {
         this.manager = manager;
         this.query = query;
-        this.sort = sort;
-        this.mergeSort = mergeSort;
+        this.indexSort = indexSort;
         this.fields = fields;
+        this.startQuery = after;
         this.page = Math.min(page, MAX_PAGE_SIZE) + 1;
+        TimeCounter time = TimeCounter.create().start();
         try {
             searcher = manager.acquire();
+            this.sort = sort.rewrite(searcher);
+            if (after != null) {
+                BooleanQuery.Builder builder = new BooleanQuery.Builder();
+                builder.add(after, BooleanClause.Occur.FILTER);
+                builder.add(query, BooleanClause.Occur.MUST);
+                ScoreDoc[] scoreDocs = searcher.search(builder.build(), 1, sort).scoreDocs;
+                if (scoreDocs.length > 0) {
+                    this.after = scoreDocs[0];
+                }
+            }
         } catch (IOException e) {
-            throw new IndexException("Error while acquiring index searcher");
+            throw new IndexException(e, "Error while acquiring index searcher");
+        } finally {
+            logger.debug("Index query initialized at position {} in {}", after, time.stop());
         }
     }
 
@@ -81,14 +100,14 @@ public class DocumentIterator implements CloseableIterator<Pair<Document, ScoreD
             TimeCounter time = TimeCounter.create().start();
 
             TopDocs topDocs;
-            if (EarlyTerminatingSortingCollector.canEarlyTerminate(sort, mergeSort)) {
+            if (startQuery == null && EarlyTerminatingSortingCollector.canEarlyTerminate(sort, indexSort)) {
                 FieldDoc fieldDoc = after == null ? null : (FieldDoc) after;
                 TopFieldCollector collector = TopFieldCollector.create(sort, page, fieldDoc, true, false, false);
                 int hits = numRead + page;
-                searcher.search(query, new EarlyTerminatingSortingCollector(collector, sort, hits, mergeSort));
+                searcher.search(query, new EarlyTerminatingSortingCollector(collector, sort, hits, indexSort));
                 topDocs = collector.topDocs();
             } else {
-                topDocs = searcher.searchAfter(after, query, page, sort.rewrite(searcher));
+                topDocs = searcher.searchAfter(after, query, page, sort);
             }
 
             ScoreDoc[] scoreDocs = topDocs.scoreDocs;

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/index/DocumentIterator.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/index/DocumentIterator.java
@@ -81,7 +81,7 @@ public class DocumentIterator implements CloseableIterator<Pair<Document, ScoreD
                 BooleanQuery.Builder builder = new BooleanQuery.Builder();
                 builder.add(after, BooleanClause.Occur.FILTER);
                 builder.add(query, BooleanClause.Occur.MUST);
-                ScoreDoc[] scoreDocs = searcher.search(builder.build(), 1, sort).scoreDocs;
+                ScoreDoc[] scoreDocs = searcher.search(builder.build(), 1, this.sort).scoreDocs;
                 if (scoreDocs.length > 0) {
                     this.after = scoreDocs[0];
                 }

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/index/FSIndex.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/index/FSIndex.java
@@ -268,13 +268,13 @@ public class FSIndex implements FSIndexMBean {
      * @param count the max number of results to be collected
      * @return the found documents, sorted according to the supplied {@link Sort} instance
      */
-    public DocumentIterator search(Query query, Sort sort, ScoreDoc after, int count) {
+    public DocumentIterator search(Query after, Query query, Sort sort, int count) {
         logger.debug("Searching in {}\n" +
-                     "count: {}\n" +
                      "after: {}\n" +
                      "query: {}\n" +
-                     " sort: {}", name, count, after, query, sort);
-        return new DocumentIterator(searcherManager, query, sort, mergeSort, count, fields);
+                     " sort: {}\n" +
+                     "count: {}", name, after, query, sort, count);
+        return new DocumentIterator(searcherManager, mergeSort, after, query, sort, count, fields);
     }
 
     /**

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/index/RAMIndex.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/index/RAMIndex.java
@@ -101,7 +101,6 @@ public class RAMIndex {
             IndexSearcher searcher = new IndexSearcher(reader);
             sort = sort.rewrite(searcher);
             TopDocs topDocs = searcher.search(query, count, sort, true, true);
-            float maxScore = topDocs.getMaxScore();
             ScoreDoc[] scoreDocs = topDocs.scoreDocs;
             List<Pair<Document, ScoreDoc>> documents = new LinkedList<>();
             for (ScoreDoc scoreDoc : scoreDocs) {

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/key/KeyMapper.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/key/KeyMapper.java
@@ -45,6 +45,7 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 
 import static org.apache.cassandra.utils.ByteBufferUtil.EMPTY_BYTE_BUFFER;
+import static org.apache.cassandra.utils.ByteBufferUtil.read;
 import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
 
 /**
@@ -204,6 +205,20 @@ public final class KeyMapper {
      */
     public Term term(DecoratedKey key, Clustering clustering) {
         return new Term(FIELD_NAME, bytesRef(key, clustering));
+    }
+
+    /**
+     * Returns the Lucene {@link Term} representing the primary key.
+     *
+     * @param key the partition key
+     * @return the Lucene {@link Term} representing the primary key
+     */
+    public Term term(ByteBuffer key) {
+        return new Term(FIELD_NAME, ByteBufferUtils.bytesRef(key));
+    }
+
+    public Clustering clustering(ByteBuffer clustering) {
+        return new Clustering(clusteringType.split(clustering));
     }
 
     /**

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/key/PartitionMapper.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/key/PartitionMapper.java
@@ -122,10 +122,19 @@ public final class PartitionMapper {
      * @param partitionKey the raw partition key to be converted
      * @return a Lucene {@link Term}
      */
-    public Term term(DecoratedKey partitionKey) {
-        ByteBuffer bb = partitionKey.getKey();
-        BytesRef bytesRef = ByteBufferUtils.bytesRef(bb);
+    public Term term(ByteBuffer partitionKey) {
+        BytesRef bytesRef = ByteBufferUtils.bytesRef(partitionKey);
         return new Term(FIELD_NAME, bytesRef);
+    }
+
+    /**
+     * Returns the specified raw partition key as a Lucene {@link Term}.
+     *
+     * @param partitionKey the raw partition key to be converted
+     * @return a Lucene {@link Term}
+     */
+    public Term term(DecoratedKey partitionKey) {
+        return term(partitionKey.getKey());
     }
 
     /**
@@ -146,6 +155,16 @@ public final class PartitionMapper {
      * @return the specified raw partition key as a Lucene {@link Query}
      */
     public Query query(DecoratedKey partitionKey) {
+        return new TermQuery(term(partitionKey));
+    }
+
+    /**
+     * Returns the specified raw partition key as a Lucene {@link Query}.
+     *
+     * @param partitionKey the raw partition key to be converted
+     * @return the specified raw partition key as a Lucene {@link Query}
+     */
+    public Query query(ByteBuffer partitionKey) {
         return new TermQuery(term(partitionKey));
     }
 

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/search/Search.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/search/Search.java
@@ -19,9 +19,11 @@ import com.google.common.base.MoreObjects;
 import com.stratio.cassandra.lucene.schema.Schema;
 import com.stratio.cassandra.lucene.search.condition.Condition;
 import com.stratio.cassandra.lucene.search.sort.Sort;
+import com.stratio.cassandra.lucene.util.ByteBufferUtils;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,6 +52,12 @@ public class Search {
     /** If this search must refresh the index before reading it. */
     private final Boolean refresh;
 
+    /** The starting partition key. */
+    private final ByteBuffer afterKey;
+
+    /** The starting clustering key. */
+    private final ByteBuffer afterClustering;
+
     /**
      * Constructor using the specified querying, filtering, sorting and refresh options.
      *
@@ -58,12 +66,21 @@ public class Search {
      * @param sort the sort for the query. Note that is the order in which the data will be read before querying, not
      * the order of the results after querying
      * @param refresh if this search must refresh the index before reading it
+     * @param afterKey the starting partition key
+     * @param afterClustering the starting clustering key
      */
-    public Search(Condition query, Condition filter, Sort sort, Boolean refresh) {
+    public Search(Condition query,
+                  Condition filter,
+                  Sort sort,
+                  Boolean refresh,
+                  ByteBuffer afterKey,
+                  ByteBuffer afterClustering) {
         this.query = query;
         this.filter = filter;
         this.sort = sort;
         this.refresh = refresh == null ? DEFAULT_FORCE_REFRESH : refresh;
+        this.afterKey = afterKey;
+        this.afterClustering = afterClustering;
     }
 
     public boolean isTopK() {
@@ -155,6 +172,14 @@ public class Search {
         return query == null ? Optional.empty() : Optional.of(query.query(schema));
     }
 
+    public ByteBuffer afterKey() {
+        return afterKey;
+    }
+
+    public ByteBuffer afterClustering() {
+        return afterClustering;
+    }
+
     /**
      * Validates this {@link Search} against the specified {@link Schema}.
      *
@@ -180,6 +205,8 @@ public class Search {
                           .add("filter", filter)
                           .add("sort", sort)
                           .add("refresh", refresh)
+                          .add("afterKey", ByteBufferUtils.toHex(afterKey))
+                          .add("afterClustering", ByteBufferUtils.toHex(afterClustering))
                           .toString();
     }
 }

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/util/ByteBufferUtils.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/util/ByteBufferUtils.java
@@ -107,7 +107,7 @@ public final class ByteBufferUtils {
      * @return the hexadecimal {@code String} representation of {@code byteBuffer}
      */
     public static String toHex(ByteBuffer byteBuffer) {
-        return ByteBufferUtil.bytesToHex(byteBuffer);
+        return byteBuffer == null ? null : ByteBufferUtil.bytesToHex(byteBuffer);
     }
 
     /**
@@ -155,11 +155,20 @@ public final class ByteBufferUtils {
      * Returns the {@link ByteBuffer} representation of the specified {@link BytesRef}.
      *
      * @param bytesRef the {@link BytesRef}
-     * @return the {@link ByteBuffer} representation of  {@code bytesRef}
+     * @return the {@link ByteBuffer} representation of {@code bytesRef}
      */
     public static ByteBuffer byteBuffer(BytesRef bytesRef) {
         byte[] bytes = bytesRef.bytes;
         return ByteBuffer.wrap(bytes, bytesRef.offset, bytesRef.offset + bytesRef.length);
     }
 
+    /**
+     * Returns the {@link ByteBuffer} representation of the specified hex {@link String}.
+     *
+     * @param hex an hexadecimal representation of a byte array
+     * @return the {@link ByteBuffer} representation of {@code hex}
+     */
+    public static ByteBuffer byteBuffer(String hex) {
+        return hex == null ? null : ByteBufferUtil.hexToBytes(hex);
+    }
 }

--- a/plugin/src/main/java/com/stratio/cassandra/lucene/util/ByteBufferUtils.java
+++ b/plugin/src/main/java/com/stratio/cassandra/lucene/util/ByteBufferUtils.java
@@ -171,4 +171,45 @@ public final class ByteBufferUtils {
     public static ByteBuffer byteBuffer(String hex) {
         return hex == null ? null : ByteBufferUtil.hexToBytes(hex);
     }
+
+    /**
+     * Returns a {@link ByteBuffer} representing the specified array of {@link ByteBuffer}s.
+     *
+     * @param bbs an array of byte buffers
+     * @return a {@link ByteBuffer} representing {@code bbs}
+     */
+    public static ByteBuffer compose(ByteBuffer... bbs) {
+        int totalLength = 2;
+        for (ByteBuffer bb : bbs) {
+            totalLength += 2 + bb.remaining();
+        }
+        ByteBuffer out = ByteBuffer.allocate(totalLength);
+
+        ByteBufferUtil.writeShortLength(out, bbs.length);
+        for (ByteBuffer bb : bbs) {
+            ByteBufferUtil.writeShortLength(out, bb.remaining());
+            out.put(bb.duplicate());
+        }
+        out.flip();
+        return out;
+    }
+
+    /**
+     * Returns the components of the specified {@link ByteBuffer} created with {@link #compose(ByteBuffer...)}.
+     *
+     * @param bb a byte buffer created with {@link #compose(ByteBuffer...)}
+     * @return the components of {@code bb}
+     */
+    public static ByteBuffer[] decompose(ByteBuffer bb) {
+
+        int countComponents = ByteBufferUtil.readShortLength(bb);
+        ByteBuffer[] components = new ByteBuffer[countComponents];
+
+        for (int i = 0; i < countComponents; i++) {
+            int length = ByteBufferUtil.readShortLength(bb);
+            components[i] = ByteBufferUtil.readBytes(bb, length);
+        }
+
+        return components;
+    }
 }

--- a/plugin/src/main/java/org/apache/cassandra/service/LuceneStorageProxy.java
+++ b/plugin/src/main/java/org/apache/cassandra/service/LuceneStorageProxy.java
@@ -15,14 +15,24 @@
  */
 package org.apache.cassandra.service;
 
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+import com.stratio.cassandra.lucene.Index;
 import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.partitions.PartitionIterator;
+import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.dht.RingPosition;
 import org.apache.cassandra.exceptions.*;
-import com.stratio.cassandra.lucene.Index;
+import org.apache.cassandra.locator.LocalStrategy;
 import org.apache.cassandra.metrics.ClientRequestMetrics;
+import org.apache.cassandra.utils.AbstractIterator;
 
 import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +45,7 @@ public class LuceneStorageProxy {
 
     private static Method systemKeyspaceQuery;
     private static Method fetchRows;
+
     static {
         try {
             systemKeyspaceQuery = StorageProxy.class.getDeclaredMethod("systemKeyspaceQuery", List.class);
@@ -55,7 +66,8 @@ public class LuceneStorageProxy {
         return (PartitionIterator) fetchRows.invoke(null, commands, cl);
     }
 
-    public static PartitionIterator read(SinglePartitionReadCommand.Group group, ConsistencyLevel consistencyLevel)
+    public static PartitionIterator read(SinglePartitionReadCommand.Group group,
+                                         ConsistencyLevel consistencyLevel)
     throws UnavailableException, IsBootstrappingException, ReadFailureException, ReadTimeoutException,
            InvalidRequestException, ReflectiveOperationException {
 
@@ -85,6 +97,7 @@ public class LuceneStorageProxy {
             }
 
             return result;
+
         } catch (UnavailableException e) {
             readMetrics.unavailables.mark();
             throw e;
@@ -104,4 +117,134 @@ public class LuceneStorageProxy {
             }
         }
     }
+
+    ///////////////////////////////////////
+
+    public static RangeMerger rangeMerger(PartitionRangeReadCommand command, ConsistencyLevel consistency) {
+        Keyspace keyspace = Keyspace.open(command.metadata().ksName);
+        RangeIterator rangeIterator = new RangeIterator(command, keyspace, consistency);
+        return new RangeMerger(rangeIterator, keyspace, consistency);
+    }
+
+    public static <T extends RingPosition<T>> List<AbstractBounds<T>> getRestrictedRanges(final AbstractBounds<T> queryRange) {
+        return StorageProxy.getRestrictedRanges(queryRange);
+    }
+
+    public static class RangeIterator extends AbstractIterator<RangeForQuery> {
+        private final Keyspace keyspace;
+        private final ConsistencyLevel consistency;
+        private final Iterator<? extends AbstractBounds<PartitionPosition>> ranges;
+        private final int rangeCount;
+
+        public RangeIterator(PartitionRangeReadCommand command, Keyspace keyspace, ConsistencyLevel consistency) {
+            this.keyspace = keyspace;
+            this.consistency = consistency;
+
+            List<? extends AbstractBounds<PartitionPosition>>
+                    l
+                    = keyspace.getReplicationStrategy() instanceof LocalStrategy
+                      ? command.dataRange().keyRange().unwrap()
+                      : getRestrictedRanges(command.dataRange().keyRange());
+            this.ranges = l.iterator();
+            this.rangeCount = l.size();
+        }
+
+        public int rangeCount() {
+            return rangeCount;
+        }
+
+        protected RangeForQuery computeNext() {
+            if (!ranges.hasNext()) {
+                return endOfData();
+            }
+
+            AbstractBounds<PartitionPosition> range = ranges.next();
+            List<InetAddress> liveEndpoints = StorageProxy.getLiveSortedEndpoints(keyspace, range.right);
+            return new RangeForQuery(range, liveEndpoints, consistency.filterForQuery(keyspace, liveEndpoints));
+        }
+    }
+
+    public static class RangeForQuery {
+        public final AbstractBounds<PartitionPosition> range;
+        public final List<InetAddress> liveEndpoints;
+        public final List<InetAddress> filteredEndpoints;
+
+        public RangeForQuery(AbstractBounds<PartitionPosition> range,
+                             List<InetAddress> liveEndpoints,
+                             List<InetAddress> filteredEndpoints) {
+            this.range = range;
+            this.liveEndpoints = liveEndpoints;
+            this.filteredEndpoints = filteredEndpoints;
+        }
+    }
+
+    public static class RangeMerger extends AbstractIterator<RangeForQuery> {
+        private final Keyspace keyspace;
+        private final ConsistencyLevel consistency;
+        private final PeekingIterator<RangeForQuery> ranges;
+
+        private RangeMerger(Iterator<RangeForQuery> iterator, Keyspace keyspace, ConsistencyLevel consistency) {
+            this.keyspace = keyspace;
+            this.consistency = consistency;
+            this.ranges = Iterators.peekingIterator(iterator);
+        }
+
+        protected RangeForQuery computeNext() {
+            if (!ranges.hasNext()) {
+                return endOfData();
+            }
+
+            RangeForQuery current = ranges.next();
+
+            // getRestrictedRange has broken the queried range into per-[vnode] token ranges, but this doesn't take
+            // the replication factor into account. If the intersection of live endpoints for 2 consecutive ranges
+            // still meets the CL requirements, then we can merge both ranges into the same RangeSliceCommand.
+            while (ranges.hasNext()) {
+                // If the current range right is the min token, we should stop merging because CFS.getRangeSlice
+                // don't know how to deal with a wrapping range.
+                // Note: it would be slightly more efficient to have CFS.getRangeSlice on the destination nodes unwraps
+                // the range if necessary and deal with it. However, we can't start sending wrapped range without breaking
+                // wire compatibility, so It's likely easier not to bother;
+                if (current.range.right.isMinimum()) {
+                    break;
+                }
+
+                RangeForQuery next = ranges.peek();
+
+                List<InetAddress> merged = intersection(current.liveEndpoints, next.liveEndpoints);
+
+                // Check if there is enough endpoint for the merge to be possible.
+                if (!consistency.isSufficientLiveNodes(keyspace, merged)) {
+                    break;
+                }
+
+                List<InetAddress> filteredMerged = consistency.filterForQuery(keyspace, merged);
+
+                // Estimate whether merging will be a win or not
+                if (!DatabaseDescriptor.getEndpointSnitch()
+                                       .isWorthMergingForRangeQuery(filteredMerged,
+                                                                    current.filteredEndpoints,
+                                                                    next.filteredEndpoints)) {
+                    break;
+                }
+
+                // If we get there, merge this range and the next one
+                current = new RangeForQuery(current.range.withNewRight(next.range.right), merged, filteredMerged);
+                ranges.next(); // consume the range we just merged since we've only peeked so far
+            }
+            return current;
+        }
+    }
+
+    private static List<InetAddress> intersection(List<InetAddress> l1, List<InetAddress> l2) {
+        // Note: we don't use Guava Sets.intersection() for 3 reasons:
+        //   1) retainAll would be inefficient if l1 and l2 are large but in practice both are the replicas for a range and
+        //   so will be very small (< RF). In that case, retainAll is in fact more efficient.
+        //   2) we do ultimately need a list so converting everything to sets don't make sense
+        //   3) l1 and l2 are sorted by proximity. The use of retainAll  maintain that sorting in the result, while using sets wouldn't.
+        List<InetAddress> inter = new ArrayList<InetAddress>(l1);
+        inter.retainAll(l2);
+        return inter;
+    }
+
 }

--- a/plugin/src/test/java/com/stratio/cassandra/lucene/index/DocumentIteratorTest.java
+++ b/plugin/src/test/java/com/stratio/cassandra/lucene/index/DocumentIteratorTest.java
@@ -114,8 +114,7 @@ public class DocumentIteratorTest {
                                                               true,
                                                               null);
         DocumentIterator docIterator = new DocumentIterator(searcherManager,
-                                                            new QueryMock(),
-                                                            new Sort(),
+                                                            new Sort(), null, new QueryMock(),
                                                             new Sort(),
                                                             0,
                                                             new HashSet<>());
@@ -130,8 +129,7 @@ public class DocumentIteratorTest {
                                                               true,
                                                               null);
         DocumentIterator docIterator = new DocumentIterator(searcherManager,
-                                                            new QueryMock(),
-                                                            new Sort(),
+                                                            new Sort(), null, new QueryMock(),
                                                             new Sort(),
                                                             1,
                                                             new HashSet<>());
@@ -146,8 +144,7 @@ public class DocumentIteratorTest {
                                                               true,
                                                               null);
         DocumentIterator docIterator = new DocumentIterator(searcherManager,
-                                                            new QueryMock(),
-                                                            new Sort(),
+                                                            new Sort(), null, new QueryMock(),
                                                             new Sort(),
                                                             DocumentIterator.MAX_PAGE_SIZE,
                                                             new HashSet<>());
@@ -162,8 +159,7 @@ public class DocumentIteratorTest {
                                                               true,
                                                               null);
         DocumentIterator docIterator = new DocumentIterator(searcherManager,
-                                                            new QueryMock(),
-                                                            new Sort(),
+                                                            new Sort(), null, new QueryMock(),
                                                             new Sort(),
                                                             10000000,
                                                             new HashSet<>());

--- a/plugin/src/test/java/com/stratio/cassandra/lucene/index/FSIndexTest.java
+++ b/plugin/src/test/java/com/stratio/cassandra/lucene/index/FSIndexTest.java
@@ -82,7 +82,7 @@ public class FSIndexTest {
         assertEquals("Expected 2 documents", 2, index.getNumDocs());
 
         Query query = new WildcardQuery(new Term("field", "value*"));
-        DocumentIterator documentIterator = index.search(query, sort, null, 1);
+        DocumentIterator documentIterator = index.search(null, query, sort, 1);
         List<Document> documents = new ArrayList<>();
         while (documentIterator.hasNext()) {
             documents.add(documentIterator.next().left);

--- a/plugin/src/test/java/com/stratio/cassandra/lucene/search/SearchTest.java
+++ b/plugin/src/test/java/com/stratio/cassandra/lucene/search/SearchTest.java
@@ -16,8 +16,6 @@
 package com.stratio.cassandra.lucene.search;
 
 import com.stratio.cassandra.lucene.schema.Schema;
-import com.stratio.cassandra.lucene.util.ByteBufferUtils;
-import org.apache.cassandra.db.marshal.UTF8Type;
 import org.junit.Test;
 
 import static com.stratio.cassandra.lucene.schema.SchemaBuilders.schema;
@@ -32,7 +30,7 @@ public class SearchTest {
 
     @Test
     public void testBuilderEmpty() {
-        Search search = new Search(null, null, null, null, null, null);
+        Search search = search().build();
         assertFalse("Default refresh is not set", search.refresh());
     }
 
@@ -41,13 +39,9 @@ public class SearchTest {
         Search search = search().query(match("field", "value"))
                                 .filter(match("field", "value"))
                                 .sort(field("field"))
-                                .afterKey("00000002")
-                                .afterClustering("00040000000300")
                                 .refresh(true)
                                 .build();
         assertTrue("Refresh is not set", search.refresh());
-        assertEquals("Key is not set", "00000002", ByteBufferUtils.toHex(search.afterKey()));
-        assertEquals("Clustering is not set", "00040000000300", ByteBufferUtils.toHex(search.afterClustering()));
     }
 
     @Test
@@ -123,15 +117,13 @@ public class SearchTest {
                                 .filter(match("field", "value").docValues(true))
                                 .sort(field("field"))
                                 .refresh(true)
-                                .afterKey(UTF8Type.instance.decompose("hello"))
-                                .afterClustering(UTF8Type.instance.decompose("bye"))
                                 .build();
         assertEquals("Method #toString is wrong",
                      "Search{" +
                      "query=MatchCondition{boost=0.5, field=field, value=value, docValues=false}, " +
                      "filter=MatchCondition{boost=null, field=field, value=value, docValues=true}, " +
                      "sort=Sort{sortFields=[SimpleSortField{field=field, reverse=false}]}, " +
-                     "refresh=true, afterKey=68656c6c6f, afterClustering=627965}",
+                     "refresh=true, paging=null}",
                      search.toString());
     }
 

--- a/plugin/src/test/java/com/stratio/cassandra/lucene/search/SearchTest.java
+++ b/plugin/src/test/java/com/stratio/cassandra/lucene/search/SearchTest.java
@@ -16,6 +16,8 @@
 package com.stratio.cassandra.lucene.search;
 
 import com.stratio.cassandra.lucene.schema.Schema;
+import com.stratio.cassandra.lucene.util.ByteBufferUtils;
+import org.apache.cassandra.db.marshal.UTF8Type;
 import org.junit.Test;
 
 import static com.stratio.cassandra.lucene.schema.SchemaBuilders.schema;
@@ -30,7 +32,7 @@ public class SearchTest {
 
     @Test
     public void testBuilderEmpty() {
-        Search search = new Search(null, null, null, null);
+        Search search = new Search(null, null, null, null, null, null);
         assertFalse("Default refresh is not set", search.refresh());
     }
 
@@ -39,9 +41,13 @@ public class SearchTest {
         Search search = search().query(match("field", "value"))
                                 .filter(match("field", "value"))
                                 .sort(field("field"))
+                                .afterKey("00000002")
+                                .afterClustering("00040000000300")
                                 .refresh(true)
                                 .build();
         assertTrue("Refresh is not set", search.refresh());
+        assertEquals("Key is not set", "00000002", ByteBufferUtils.toHex(search.afterKey()));
+        assertEquals("Clustering is not set", "00040000000300", ByteBufferUtils.toHex(search.afterClustering()));
     }
 
     @Test
@@ -117,12 +123,15 @@ public class SearchTest {
                                 .filter(match("field", "value").docValues(true))
                                 .sort(field("field"))
                                 .refresh(true)
+                                .afterKey(UTF8Type.instance.decompose("hello"))
+                                .afterClustering(UTF8Type.instance.decompose("bye"))
                                 .build();
         assertEquals("Method #toString is wrong",
-                     "Search{query=MatchCondition{boost=0.5, field=field, value=value, docValues=false}, " +
+                     "Search{" +
+                     "query=MatchCondition{boost=0.5, field=field, value=value, docValues=false}, " +
                      "filter=MatchCondition{boost=null, field=field, value=value, docValues=true}, " +
                      "sort=Sort{sortFields=[SimpleSortField{field=field, reverse=false}]}, " +
-                     "refresh=true}",
+                     "refresh=true, afterKey=68656c6c6f, afterClustering=627965}",
                      search.toString());
     }
 

--- a/plugin/src/test/java/com/stratio/cassandra/lucene/util/ByteBufferUtilsTest.java
+++ b/plugin/src/test/java/com/stratio/cassandra/lucene/util/ByteBufferUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package com.stratio.cassandra.lucene.util;
 
+import org.apache.cassandra.db.marshal.BooleanType;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
@@ -83,5 +84,22 @@ public class ByteBufferUtilsTest {
         ByteBuffer bb = type.decompose("monkey", 1);
         String string = ByteBufferUtils.toString(bb, type);
         assertEquals("Composite type string conversion is failing", "monkey:1", string);
+    }
+
+    @Test
+    public void testComposeDecompose() {
+        ByteBuffer[] bbs = ByteBufferUtils.decompose(ByteBufferUtils.compose(UTF8Type.instance.decompose("test"),
+                                                                             Int32Type.instance.decompose(999),
+                                                                             BooleanType.instance.decompose(true)));
+        assertEquals("Compose-decompose is wrong", 3, bbs.length);
+        assertEquals("Compose-decompose is wrong", "test", UTF8Type.instance.compose(bbs[0]));
+        assertEquals("Compose-decompose is wrong", 999, Int32Type.instance.compose(bbs[1]), 0);
+        assertEquals("Compose-decompose is wrong", true, BooleanType.instance.compose(bbs[2]));
+    }
+
+    @Test
+    public void testComposeDecomposeEmpty() {
+        ByteBuffer[] bbs = ByteBufferUtils.decompose(ByteBufferUtils.compose());
+        assertEquals("Compose-decompose with empty components is wrong", 0, bbs.length);
     }
 }

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/suite/VariaSuite.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/suite/VariaSuite.java
@@ -31,7 +31,7 @@ import org.junit.runners.Suite.SuiteClasses;
                SearchWithLongWideRowsAT.class,
                ReadStaticColumnsAT.class,
                UDFsAT.class,
-               BoundStatementWitTopKQuery.class,
+               BoundStatementWithSortedKQuery.class,
                StatelessSearchWithSkinnyRowsAT.class,
                StatelessSearchWithWideRowsAT.class})
 public class VariaSuite {

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/util/CassandraConfig.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/util/CassandraConfig.java
@@ -37,7 +37,7 @@ class CassandraConfig {
     static final String INDEX = getString("index", "test_table_idx");
     static final String COLUMN = getString("column", null);
     static final boolean USE_NEW_QUERY_SYNTAX = getBool("use_new_query_syntax", true);
-    static final int LIMIT = getInt("limit", 10000); // Top-k
+    static final int LIMIT = getInt("limit", 10000);
 
     static {
         assert COLUMN != null || USE_NEW_QUERY_SYNTAX;

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/varia/BoundStatementWithSortedKQuery.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/varia/BoundStatementWithSortedKQuery.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertArrayEquals;
  * @author Eduardo Alonso {@literal <eduardoalonso@stratio.com>}
  */
 @RunWith(JUnit4.class)
-public class BoundStatementWitTopKQuery extends AbstractSearchAT {
+public class BoundStatementWithSortedKQuery extends AbstractSearchAT {
 
     private static Integer[] intColumn(List<Row> rows, String name) {
         Integer[] values = new Integer[rows.size()];

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/varia/InOperatorWithSkinnyRowsAT.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/varia/InOperatorWithSkinnyRowsAT.java
@@ -68,11 +68,11 @@ public class InOperatorWithSkinnyRowsAT extends BaseAT {
 
     @Test
     public void queryWithInTest() {
-        utils.query(all()).and("AND pk IN (9, 5, 0)").checkIntColumn("rc", 5, 0, 9);
+        utils.query(all()).fetchSize(4).and("AND pk IN (9, 5, 0)").checkIntColumn("rc", 5, 0, 9);
     }
 
     @Test
     public void sortWithInTest() {
-        utils.sort(field("pk")).and("AND pk IN (9, 5, 0)").checkIntColumn("rc", 0, 5, 9);
+        utils.sort(field("pk")).fetchSize(4).and("AND pk IN (9, 5, 0)").checkIntColumn("rc", 0, 5, 9);
     }
 }

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/varia/SearchWithLongSkinnyRowsAT.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/varia/SearchWithLongSkinnyRowsAT.java
@@ -25,42 +25,41 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.stratio.cassandra.lucene.builder.Builder.all;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Andres de la Pena <adelapena@stratio.com>
  */
 public class SearchWithLongSkinnyRowsAT extends BaseAT {
 
-    private static CassandraUtils cassandraUtils;
+    private static CassandraUtils utils;
 
     @BeforeClass
     public static void before() {
 
-        cassandraUtils = CassandraUtils.builder("search_with_long_skinny_rows")
-                                       .withPartitionKey("id")
-                                       .withColumn("id", "int")
-                                       .withColumn("ascii_1", "ascii")
-                                       .withColumn("bigint_1", "bigint")
-                                       .withColumn("blob_1", "blob")
-                                       .withColumn("boolean_1", "boolean")
-                                       .withColumn("decimal_1", "decimal")
-                                       .withColumn("date_1", "timestamp")
-                                       .withColumn("double_1", "double")
-                                       .withColumn("float_1", "float")
-                                       .withColumn("integer_1", "int")
-                                       .withColumn("inet_1", "inet")
-                                       .withColumn("text_1", "text")
-                                       .withColumn("varchar_1", "varchar")
-                                       .withColumn("uuid_1", "uuid")
-                                       .withColumn("timeuuid_1", "timeuuid")
-                                       .withColumn("list_1", "list<text>")
-                                       .withColumn("set_1", "set<text>")
-                                       .withColumn("map_1", "map<text,text>")
-                                       .build()
-                                       .createKeyspace()
-                                       .createTable()
-                                       .createIndex();
+        utils = CassandraUtils.builder("search_with_long_skinny_rows")
+                              .withPartitionKey("id")
+                              .withColumn("id", "int")
+                              .withColumn("ascii_1", "ascii")
+                              .withColumn("bigint_1", "bigint")
+                              .withColumn("blob_1", "blob")
+                              .withColumn("boolean_1", "boolean")
+                              .withColumn("decimal_1", "decimal")
+                              .withColumn("date_1", "timestamp")
+                              .withColumn("double_1", "double")
+                              .withColumn("float_1", "float")
+                              .withColumn("integer_1", "int")
+                              .withColumn("inet_1", "inet")
+                              .withColumn("text_1", "text")
+                              .withColumn("varchar_1", "varchar")
+                              .withColumn("uuid_1", "uuid")
+                              .withColumn("timeuuid_1", "timeuuid")
+                              .withColumn("list_1", "list<text>")
+                              .withColumn("set_1", "set<text>")
+                              .withColumn("map_1", "map<text,text>")
+                              .build()
+                              .createKeyspace()
+                              .createTable()
+                              .createIndex();
         for (Integer p = 0; p < 2; p++) {
             for (Integer i = 1; i <= 100; i++) {
                 Map<String, String> data = new LinkedHashMap<>();
@@ -82,74 +81,64 @@ public class SearchWithLongSkinnyRowsAT extends BaseAT {
                 data.put("list_1", "['l2','l3']");
                 data.put("set_1", "{'s2','s3'}");
                 data.put("map_1", "{'k2':'v2','k3':'v3'}");
-                cassandraUtils.insert(data);
+                utils.insert(data);
             }
         }
-        cassandraUtils.refresh();
+        utils.refresh();
     }
 
     @AfterClass
     public static void after() {
-        cassandraUtils.dropIndex().dropTable().dropKeyspace();
+        utils.dropIndex().dropTable().dropKeyspace();
     }
 
     @Test
     public void query1Test() {
-        int n = cassandraUtils.query(all()).fetchSize(10).limit(1).count();
-        assertEquals("Expected 1 results!", 1, n);
+        utils.query(all()).fetchSize(10).limit(1).check(1);
     }
 
     @Test
     public void query99Test() {
-        int n = cassandraUtils.query(all()).fetchSize(10).limit(99).count();
-        assertEquals("Expected 99 results!", 99, n);
+        utils.query(all()).fetchSize(10).limit(99).check(99);
     }
 
     @Test
     public void query100Test() {
-        int n = cassandraUtils.query(all()).fetchSize(10).limit(100).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.query(all()).fetchSize(10).limit(100).check(100);
     }
 
     @Test
     public void query101Test() {
-        int n = cassandraUtils.query(all()).fetchSize(10).limit(101).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.query(all()).fetchSize(10).limit(101).check(100);
     }
 
     @Test
     public void query1000Test() {
-        int n = cassandraUtils.query(all()).limit(1000).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.query(all()).limit(1000).check(100);
     }
 
     @Test
     public void filter1Test() {
-        int n = cassandraUtils.filter(all()).fetchSize(10).limit(1).count();
-        assertEquals("Expected 1 results!", 1, n);
+        utils.filter(all()).fetchSize(10).limit(1).check(1);
     }
 
     @Test
     public void filter99Test() {
-        int n = cassandraUtils.filter(all()).fetchSize(10).limit(99).count();
-        assertEquals("Expected 99 results!", 99, n);
+        utils.filter(all()).fetchSize(10).limit(99).check(99);
     }
 
     @Test
     public void filter100Test() {
-        int n = cassandraUtils.filter(all()).fetchSize(10).limit(100).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.filter(all()).fetchSize(10).limit(100).check(100);
     }
 
     @Test
     public void filter101Test() {
-        int n = cassandraUtils.filter(all()).fetchSize(10).limit(101).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.filter(all()).fetchSize(10).limit(101).check(100);
     }
 
     @Test
     public void filter1000Test() {
-        int n = cassandraUtils.filter(all()).limit(1000).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.filter(all()).limit(1000).check(100);
     }
 }

--- a/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/varia/SearchWithLongWideRowsAT.java
+++ b/testsAT/src/test/java/com/stratio/cassandra/lucene/testsAT/varia/SearchWithLongWideRowsAT.java
@@ -33,37 +33,37 @@ import static org.junit.Assert.assertEquals;
  */
 public class SearchWithLongWideRowsAT extends BaseAT {
 
-    private static CassandraUtils cassandraUtils;
+    private static CassandraUtils utils;
 
     @BeforeClass
     public static void before() {
 
-        cassandraUtils = CassandraUtils.builder("search_with_long_wide_rows")
-                                       .withPartitionKey("partition")
-                                       .withClusteringKey("id")
-                                       .withColumn("partition", "int")
-                                       .withColumn("id", "int")
-                                       .withColumn("ascii_1", "ascii")
-                                       .withColumn("bigint_1", "bigint")
-                                       .withColumn("blob_1", "blob")
-                                       .withColumn("boolean_1", "boolean")
-                                       .withColumn("decimal_1", "decimal")
-                                       .withColumn("date_1", "timestamp")
-                                       .withColumn("double_1", "double")
-                                       .withColumn("float_1", "float")
-                                       .withColumn("integer_1", "int")
-                                       .withColumn("inet_1", "inet")
-                                       .withColumn("text_1", "text")
-                                       .withColumn("varchar_1", "varchar")
-                                       .withColumn("uuid_1", "uuid")
-                                       .withColumn("timeuuid_1", "timeuuid")
-                                       .withColumn("list_1", "list<text>")
-                                       .withColumn("set_1", "set<text>")
-                                       .withColumn("map_1", "map<text,text>")
-                                       .build()
-                                       .createKeyspace()
-                                       .createTable()
-                                       .createIndex();
+        utils = CassandraUtils.builder("search_with_long_wide_rows")
+                              .withPartitionKey("partition")
+                              .withClusteringKey("id")
+                              .withColumn("partition", "int")
+                              .withColumn("id", "int")
+                              .withColumn("ascii_1", "ascii")
+                              .withColumn("bigint_1", "bigint")
+                              .withColumn("blob_1", "blob")
+                              .withColumn("boolean_1", "boolean")
+                              .withColumn("decimal_1", "decimal")
+                              .withColumn("date_1", "timestamp")
+                              .withColumn("double_1", "double")
+                              .withColumn("float_1", "float")
+                              .withColumn("integer_1", "int")
+                              .withColumn("inet_1", "inet")
+                              .withColumn("text_1", "text")
+                              .withColumn("varchar_1", "varchar")
+                              .withColumn("uuid_1", "uuid")
+                              .withColumn("timeuuid_1", "timeuuid")
+                              .withColumn("list_1", "list<text>")
+                              .withColumn("set_1", "set<text>")
+                              .withColumn("map_1", "map<text,text>")
+                              .build()
+                              .createKeyspace()
+                              .createTable()
+                              .createIndex();
         for (Integer p = 0; p < 2; p++) {
             for (Integer i = 1; i <= 100; i++) {
                 Map<String, String> data = new LinkedHashMap<>();
@@ -86,98 +86,84 @@ public class SearchWithLongWideRowsAT extends BaseAT {
                 data.put("list_1", "['l2','l3']");
                 data.put("set_1", "{'s2','s3'}");
                 data.put("map_1", "{'k2':'v2','k3':'v3'}");
-                cassandraUtils.insert(data);
+                utils.insert(data);
             }
         }
-        cassandraUtils.refresh();
+        utils.refresh();
     }
 
     @AfterClass
     public static void after() {
-        cassandraUtils.dropIndex().dropTable().dropKeyspace();
+        utils.dropIndex().dropTable().dropKeyspace();
     }
 
     @Test
     public void query99Test() {
-        int n = cassandraUtils.query(match("partition", 0)).fetchSize(10).limit(99).count();
-        assertEquals("Expected 99 results!", 99, n);
+        utils.query(match("partition", 0)).fetchSize(10).limit(99).check(99);
     }
 
     @Test
     public void query100Test() {
-        int n = cassandraUtils.query(match("partition", 0)).fetchSize(10).limit(100).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.query(match("partition", 0)).fetchSize(10).limit(100).check(100);
     }
 
     @Test
     public void query101Test() {
-        int n = cassandraUtils.query(match("partition", 0)).fetchSize(10).limit(101).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.query(match("partition", 0)).fetchSize(10).limit(101).check(100);
     }
 
     @Test
     public void query1000Test() {
-        int n = cassandraUtils.query(match("partition", 0)).fetchSize(10).limit(1000).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.query(match("partition", 0)).fetchSize(10).limit(1000).check(100);
     }
 
     @Test
     public void queryAll200Test() {
-        int n = cassandraUtils.query(all()).limit(200).fetchSize(7).count();
-        assertEquals("Expected 200 results!", 200, n);
+        utils.query(all()).limit(200).fetchSize(7).check(200);
     }
 
     @Test
     public void queryAll1200Test() {
-        int n = cassandraUtils.query(all()).limit(201).fetchSize(4).count();
-        assertEquals("Expected 200 results!", 200, n);
+        utils.query(all()).limit(201).fetchSize(4).check(200);
     }
 
     @Test
     public void queryAll199Test() {
-        int n = cassandraUtils.query(all()).limit(199).fetchSize(13).count();
-        assertEquals("Expected 199 results!", 199, n);
+        utils.query(all()).limit(199).fetchSize(13).check(199);
     }
 
     @Test
     public void filter99Test() {
-        int n = cassandraUtils.filter(match("partition", 0)).fetchSize(10).limit(99).count();
-        assertEquals("Expected 99 results!", 99, n);
+        utils.filter(match("partition", 0)).fetchSize(10).limit(99).check(99);
     }
 
     @Test
     public void filter100Test() {
-        int n = cassandraUtils.filter(match("partition", 0)).fetchSize(10).limit(100).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.filter(match("partition", 0)).fetchSize(10).limit(100).check(100);
     }
 
     @Test
     public void filter101Test() {
-        int n = cassandraUtils.filter(match("partition", 0)).fetchSize(10).limit(101).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.filter(match("partition", 0)).fetchSize(10).limit(101).check(100);
     }
 
     @Test
     public void filter1000Test() {
-        int n = cassandraUtils.filter(match("partition", 0)).fetchSize(10).limit(1000).count();
-        assertEquals("Expected 100 results!", 100, n);
+        utils.filter(match("partition", 0)).fetchSize(10).limit(1000).check(100);
     }
 
     @Test
     public void filterAll200Test() {
-        int n = cassandraUtils.filter(all()).limit(200).fetchSize(7).count();
-        assertEquals("Expected 200 results!", 200, n);
+        utils.filter(all()).limit(200).fetchSize(7).check(200);
     }
 
     @Test
     public void filterAll1200Test() {
-        int n = cassandraUtils.filter(all()).limit(201).fetchSize(4).count();
-        assertEquals("Expected 200 results!", 200, n);
+        utils.filter(all()).limit(201).fetchSize(4).check(200);
     }
 
     @Test
     public void filterAll199Test() {
-        int n = cassandraUtils.filter(all()).limit(199).fetchSize(13).count();
-        assertEquals("Expected 199 results!", 199, n);
+        utils.filter(all()).limit(199).fetchSize(13).check(199);
     }
 }


### PR DESCRIPTION
Adds support for CQL paging over sorted searches. This is done with a new Lucene query paging state embedded into the regular CQL query paging state. This pager tracks tracks the primary keys of the last seen row of each internal read command of a CQL query.  The pager is passed to the search service, which is able to locate the score doc of the last visited document and continue the search after it.