### PR TITLE
Fix build error for branch-3.10

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>cassandra-lucene-index-parent</artifactId>
         <groupId>com.stratio.cassandra</groupId>
-        <version>3.0.10.4-RC1-SNAPSHOT</version>
+        <version>3.10.0-RC1-SNAPSHOT</version>
     </parent>
 
     <artifactId>dist</artifactId>


### PR DESCRIPTION
Non-resolvable parent POM for com.stratio.cassandra:dist:[unknown-version]: Could not find artifact com.stratio.cassandra:cassandra-lucene-index-parent:pom:3.0.10.4-RC1-SNAPSHOT and 'parent.relativePath' points at wrong local POM