### PR TITLE
Optimize compaction

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -583,6 +583,9 @@ All options take a value enclosed in single quotes:
    The cost of this optimization is an extra comparison performed each time a row must be indexed.
    This flag helps in reducing lucene calls when the row is updated partially, and the columns
    that affect the index are updated less frequently then the rest of the row.
+-  **use_ttl**: If false, deletion of data using `USING TTL` will not be performed automatically.
+   This reduces reading of data during compaction.
+   In some cases, the speed of compaction is greatly improved.
 -  **schema**: see below
 
 .. code-block:: sql

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexOptions.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexOptions.scala
@@ -69,7 +69,9 @@ class IndexOptions(tableMetadata: CFMetaData, indexMetadata: IndexMetadata) {
   val path = parsePath(options, tableMetadata, Some(indexMetadata))
 
   /** If the index is sparse or not */
-  val sparse = parseSparse(options, tableMetadata)
+  val sparse = parseBool(options, SPARSE_OPTION, DEFAULT_SPARSE)
+
+  val useTtl = parseBool(options, USE_TTL, DEFAULT_USE_TTL)
 }
 
 /** Companion object for [[IndexOptions]]. */
@@ -106,6 +108,9 @@ object IndexOptions {
 
   val SPARSE_OPTION = "sparse"
   val DEFAULT_SPARSE = false
+
+  val USE_TTL = "use_ttl"
+  val DEFAULT_USE_TTL = true
 
   /** Validates the specified index options.
     *
@@ -192,12 +197,12 @@ object IndexOptions {
       }).getOrElse(DEFAULT_PARTITIONER)
   }
 
-  def parseSparse(options: Map[String, String], table: CFMetaData): Boolean = {
-    options.get(SPARSE_OPTION).map(
+  def parseBool(options: Map[String, String], name: String, default: Boolean): Boolean = {
+    options.get(name).map(
       value => try value.toBoolean catch {
         case e: Exception => throw new IndexException(e,
-          s"'$SPARSE_OPTION' is invalid : ${e.getMessage}")
-      }).getOrElse(DEFAULT_SPARSE)
+          s"'$name' is invalid : ${e.getMessage}")
+      }).getOrElse(default)
   }
 
   private def parseInt(options: Map[String, String], name: String, default: Int): Int = {

--- a/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexWriter.scala
+++ b/plugin/src/main/scala/com/stratio/cassandra/lucene/IndexWriter.scala
@@ -20,7 +20,7 @@ import org.apache.cassandra.db._
 import org.apache.cassandra.db.rows.{Row, RowIterator, UnfilteredRowIterators}
 import org.apache.cassandra.index.Index.Indexer
 import org.apache.cassandra.index.transactions.IndexTransaction
-import org.apache.cassandra.index.transactions.IndexTransaction.Type.CLEANUP
+import org.apache.cassandra.index.transactions.IndexTransaction.Type.{CLEANUP, COMPACTION}
 import org.apache.cassandra.utils.concurrent.OpOrder
 
 /** [[Indexer]] for Lucene-based index.
@@ -116,6 +116,7 @@ abstract class IndexWriter(
 
     // Skip on cleanups
     if (transactionType == CLEANUP) return
+    if (transactionType == COMPACTION && !service.options.useTtl) return
 
     // Finish with mutual exclusion on partition
     service.readBeforeWriteLocker.run(key, () => commit())


### PR DESCRIPTION
## summary

- Add `use_ttl` new option.
- if `use_ttl = false`, disable unnecessary partition reading at compaction.

```sql
-- examle create table queries.
CREATE CUSTOM INDEX table_index ON ks1.table ()
USING 'com.stratio.cassandra.lucene.Index'
WITH OPTIONS = {
    'refresh_seconds': '15',
    'use_ttl': false,
    'partitioner': '{type: "vnode", vnodes_per_partition: 8}',
    'schema': '{
      fields: {
          filed: {type: "string"}
      }
    }'
};
```

## describe

I was investigating the compaction speed when enabling this plug-in.

When SSTable increased, the speed of compaction fell below 1%. I anticipate that read latency will be higher. Then I checked if it really needed partition reading at compaction time.

https://github.com/Stratio/cassandra-lucene-index/commit/72c48759aef25650270aca92ffa9b34e6b909cf9#diff-298e208e90f66d25100b3cd7dbf19d5bR71

This code was added for support TTL . If do not use TTL, this overhead is unnecessary ...? I put in debugging code in IndexWriterWide#commit(). What is SinglePartitionReadCommand reading when transactiontype == COMPACTION? As a result, did not read anything. So I added a flag to disable this.

(I do not fully understand the life cycle of Cassandra Indexer. Please point out if there is a mistake.)

