### PR TITLE
Fix excluded datacenters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add 'max_clauses' to boolean query
 * Fix cassandra directory sharing.
+* Fix excluded_data_centers options for index creation.
 
 ## 3.0.14.0 (June 27, 2017)
 


### PR DESCRIPTION
Feature "excluded_data_centers" was not working, although user specified this option in index creation the index was created in all datacenters.